### PR TITLE
Fixed BlockCode().

### DIFF
--- a/mangen/mangen.go
+++ b/mangen/mangen.go
@@ -39,7 +39,7 @@ func (m *Man) TitleBlock(out *bytes.Buffer, text []byte) {
 func (m *Man) BlockCode(out *bytes.Buffer, text []byte, lang string) {
 	out.WriteString("\n.PP\n.RS\n\n.nf\n")
 	escapeSpecialChars(out, text)
-	out.WriteString("\n.fi\n")
+	out.WriteString("\n.fi\n.RE\n")
 }
 
 func (m *Man) BlockQuote(out *bytes.Buffer, text []byte) {


### PR DESCRIPTION
When emitting .RS, also emit .RE to close the indentation.

I found this while trying to understand the docker man pages. :-)