### PR TITLE
md2man usable as a library (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+go-md2man

--- a/md2man.go
+++ b/md2man.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/russross/blackfriday"
+	"github.com/cpuguy83/go-md2man/md2man"
 )
 
 var inFilePath = flag.String("in", "", "Path to file to be processed")
@@ -28,17 +28,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	renderer := RoffRenderer(0)
-	extensions := 0
-	extensions |= blackfriday.EXTENSION_NO_INTRA_EMPHASIS
-	extensions |= blackfriday.EXTENSION_TABLES
-	extensions |= blackfriday.EXTENSION_FENCED_CODE
-	extensions |= blackfriday.EXTENSION_AUTOLINK
-	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
-	extensions |= blackfriday.EXTENSION_FOOTNOTES
-	extensions |= blackfriday.EXTENSION_TITLEBLOCK
-
-	out := blackfriday.Markdown(doc, renderer, extensions)
+	out := md2man.Render(doc)
 
 	outFile, err := os.Create(*outFilePath)
 	if err != nil {

--- a/md2man/md2man.go
+++ b/md2man/md2man.go
@@ -1,0 +1,19 @@
+package md2man
+
+import (
+	"github.com/russross/blackfriday"
+)
+
+func Render(doc []byte) []byte {
+	renderer := RoffRenderer(0)
+	extensions := 0
+	extensions |= blackfriday.EXTENSION_NO_INTRA_EMPHASIS
+	extensions |= blackfriday.EXTENSION_TABLES
+	extensions |= blackfriday.EXTENSION_FENCED_CODE
+	extensions |= blackfriday.EXTENSION_AUTOLINK
+	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
+	extensions |= blackfriday.EXTENSION_FOOTNOTES
+	extensions |= blackfriday.EXTENSION_TITLEBLOCK
+
+	return blackfriday.Markdown(doc, renderer, extensions)
+}

--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -1,4 +1,4 @@
-package main
+package md2man
 
 import (
 	"bytes"


### PR DESCRIPTION
d92bbe0a08731ac0747acbda45810ea3ab41d10c moved things from mangen into
the root subdir and changed the package to main. While this makes
sense for this utility others use go-md2man to generate docs automatically.
Instead of building a binary to do it. Move roff back out to a package
which can get included and used by others.

Including github.com/cpuguy83/go-md2man seems reasonable but has 2
problems.

1) now you likely have two `func main()` in package main
2) go-md2man defined `in` and `out` flags which would then show up in
   auto generated lists of flags in these other projects