### PR TITLE
Improve man page rendering

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -11,6 +11,8 @@ import (
 
 type roffRenderer struct{}
 
+var listCounter int
+
 func RoffRenderer(flags int) blackfriday.Renderer {
 	return &roffRenderer{}
 }
@@ -33,8 +35,12 @@ func (r *roffRenderer) TitleBlock(out *bytes.Buffer, text []byte) {
 		line = append(line, []byte("\" ")...)
 		out.Write(line)
 	}
+	out.WriteString("\n")
 
-	out.WriteString(" \"\"\n")
+	// disable hyphenation
+	out.WriteString(".nh\n")
+	// disable justification (adjust text to left margin only)
+	out.WriteString(".ad l\n")
 }
 
 func (r *roffRenderer) BlockCode(out *bytes.Buffer, text []byte, lang string) {
@@ -80,23 +86,24 @@ func (r *roffRenderer) HRule(out *bytes.Buffer) {
 
 func (r *roffRenderer) List(out *bytes.Buffer, text func() bool, flags int) {
 	marker := out.Len()
-	out.WriteString(".IP ")
 	if flags&blackfriday.LIST_TYPE_ORDERED != 0 {
-		out.WriteString("\\(bu 2")
-	} else {
-		out.WriteString("\\n+[step" + string(flags) + "]")
+		listCounter = 1
 	}
-	out.WriteString("\n")
 	if !text() {
 		out.Truncate(marker)
 		return
 	}
-
 }
 
 func (r *roffRenderer) ListItem(out *bytes.Buffer, text []byte, flags int) {
-	out.WriteString("\n\\item ")
+	if flags&blackfriday.LIST_TYPE_ORDERED != 0 {
+		out.WriteString(fmt.Sprintf(".IP \"%3d.\" 5\n", listCounter))
+		listCounter += 1
+	} else {
+		out.WriteString(".IP \\(bu 2\n")
+	}
 	out.Write(text)
+	out.WriteString("\n")
 }
 
 func (r *roffRenderer) Paragraph(out *bytes.Buffer, text func() bool) {
@@ -249,6 +256,11 @@ func needsBackslash(c byte) bool {
 
 func escapeSpecialChars(out *bytes.Buffer, text []byte) {
 	for i := 0; i < len(text); i++ {
+		// escape initial apostrophe or period
+		if len(text) >= 1 && (text[0] == '\'' || text[0] == '.') {
+			out.WriteString("\\&")
+		}
+
 		// directly copy normal characters
 		org := i
 


### PR DESCRIPTION
 * Disable hyphenation
 * Disable justification (adjust text to left margin only)
 * Fix output for bulleted lists and numbered lists
 * Escape initial apostrophe and period to prevent a line of text
   from being misinterpreted as a request/macro, leading to
   "warning: macro 'xxx' not defined" and missing text.

----

I ran into problems with two of the man pages from [Hugo](https://github.com/spf13/hugo) and [Cobra](https://github.com/spf13/cobra), hence this pull request.  Many thanks!