### PR TITLE
improve link

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -192,6 +192,7 @@ func (r *roffRenderer) LineBreak(out *bytes.Buffer) {
 }
 
 func (r *roffRenderer) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {
+	out.Write(content)
 	r.AutoLink(out, link, 0)
 }
 


### PR DESCRIPTION
I suggest this for improving the readability of Docker's man pages.

![image](https://cloud.githubusercontent.com/assets/9248427/18199613/16acb4fc-713c-11e6-8d5b-00068756aa29.png)


If you have considered that and intentionally skipping the link content, please close this PR :sweat_smile: 

