### PR TITLE
Fix links rendering for v2

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -160,7 +160,7 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 		// no action as cell entries do all the nroff formatting
 		return blackfriday.GoToNext
 	default:
-		fmt.Fprintf(os.Stderr, "WARNING: go-md2man does not handle node type "+node.Type.String())
+		fmt.Fprintln(os.Stderr, "WARNING: go-md2man does not handle node type "+node.Type.String())
 	}
 	return walkAction
 }

--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -108,10 +108,8 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 			out(w, strongCloseTag)
 		}
 	case blackfriday.Link:
-		if entering {
-			out(w, linkTag+string(node.LinkData.Destination))
-		} else {
-			out(w, linkCloseTag)
+		if !entering {
+			out(w, linkTag+string(node.LinkData.Destination)+linkCloseTag)
 		}
 	case blackfriday.Image:
 		// ignore images

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -270,6 +270,14 @@ robin	red.
 	doTestsInlineParam(t, tests, TestParams{blackfriday.Tables})
 }
 
+func TestLinks(t *testing.T) {
+	var tests = []string{
+		"See [docs](https://docs.docker.com/) for\nmore",
+		".nh\n\n.PP\nSee docs\n\\[la]https://docs.docker.com/\\[ra] for\nmore\n",
+	}
+	doTestsInline(t, tests)
+}
+
 func execRecoverableTestSuite(t *testing.T, tests []string, params TestParams, suite func(candidate *string)) {
 	// Catch and report panics. This is useful when running 'go test -v' on
 	// the integration server. When developing, though, crash dump is often


### PR DESCRIPTION
Since the switch to blackfriday v2, links are rendered incorrectly: link target and link text are contatenated together, like this:
    
Input:
    
     the [Docker documentation](https://docs.docker.com/) for
    
Output:
    
     the \n\\[la]https://docs.docker.com/Docker documentation\\[ra] for
    
Fix this, and provide a test case.

While at it, fix the contatenation of unhandled errors due to missing newline.

Cc: @estesp 