### PR TITLE
should use https://github.com/russross/blackfriday/releases/v2.0.1 in…

### DIFF
--- a/md2man/md2man.go
+++ b/md2man/md2man.go
@@ -1,7 +1,7 @@
 package md2man
 
 import (
-	"github.com/russross/blackfriday/v2"
+	"github.com/russross/blackfriday/v2.0.1"
 )
 
 // Render converts a markdown document into a roff formatted document.


### PR DESCRIPTION
…stead?

should use https://github.com/russross/blackfriday/releases/v2.0.1 instead?

[ERROR]   Error scanning github.com/russross/blackfriday/v2: cannot find package "." in:
        /Users/mac/.glide/cache/src/https-github.com-russross-blackfriday/v2
[ERROR]   Failed to retrieve a list of dependencies: Error resolving imports