### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/russross/blackfriday/v2 v2.0.1
+	github.com/russross/blackfriday/v2.0.1
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 )


### PR DESCRIPTION
should use https://github.com/russross/blackfriday/releases/v2.0.1 instead?