### PR TITLE
Remove escaping tilde character

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -310,7 +310,7 @@ func out(w io.Writer, output string) {
 }
 
 func needsBackslash(c byte) bool {
-	for _, r := range []byte("-_&\\~") {
+	for _, r := range []byte("-_&\\") {
 		if c == r {
 			return true
 		}

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -278,6 +278,14 @@ func TestLinks(t *testing.T) {
 	doTestsInline(t, tests)
 }
 
+func TestEscapeCharacters(t *testing.T) {
+	var tests = []string{
+		"Test-one_two&three\\four~five",
+		".nh\n\n.PP\nTest\\-one\\_two\\&three\\\\four~five\n",
+	}
+	doTestsInline(t, tests)
+}
+
 func execRecoverableTestSuite(t *testing.T, tests []string, params TestParams, suite func(candidate *string)) {
 	// Catch and report panics. This is useful when running 'go test -v' on
 	// the integration server. When developing, though, crash dump is often


### PR DESCRIPTION
Hi, I stumbled into this issue when I was working on improving other man pages that are using this library to convert them from Markdown. However, no matter what I did, it was generating the wrong output when a tilde (~) was in the file. So, I removed it from the escaped characters and added a unit test for the escaped characters (including not escaping the tilde).

This PR resolves #26