### PR TITLE
chore: set go minimal version to 1.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cpuguy83/go-md2man/v2
 
-go 1.12
+go 1.11
 
 require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect


### PR DESCRIPTION
The codebase is compatible with Go 1.12.