### PR TITLE
Ignore unknown HTML tags to prevent noisy warnings

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -157,6 +157,8 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 	case blackfriday.TableRow:
 		// no action as cell entries do all the nroff formatting
 		return blackfriday.GoToNext
+	case blackfriday.HTMLSpan:
+		// ignore other HTML tags
 	default:
 		fmt.Fprintln(os.Stderr, "WARNING: go-md2man does not handle node type "+node.Type.String())
 	}

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -287,6 +287,40 @@ func TestEscapeCharacters(t *testing.T) {
 	doTestsInline(t, tests)
 }
 
+func TestSpan(t *testing.T) {
+	var tests = []string{
+		"Text containing a <span>html span</span> element\n",
+		".nh\n\n.PP\nText containing a html span element\n",
+
+		`Text containing an inline <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><image href="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" height="200" width="200"/></svg>SVG image`,
+		".nh\n\n.PP\nText containing an inline SVG image\n",
+
+		"Text containing a <span id=\"e-123\" class=\"foo\">html span</span> element\n",
+		".nh\n\n.PP\nText containing a html span element\n",
+	}
+	doTestsInline(t, tests)
+}
+
+func TestEmails(t *testing.T) {
+	var tests = []string{
+		`April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+July 2014, updated by Sven Dowideit (SvenDowideit@home.org.au)
+`,
+		`.nh
+
+.PP
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit SvenDowideit@home.org.au
+\[la]mailto:SvenDowideit@home.org.au\[ra]
+July 2014, updated by Sven Dowideit (SvenDowideit@home.org.au)
+`,
+	}
+	doTestsInline(t, tests)
+}
+
 func execRecoverableTestSuite(t *testing.T, tests []string, params TestParams, suite func(candidate *string)) {
 	// Catch and report panics. This is useful when running 'go test -v' on
 	// the integration server. When developing, though, crash dump is often


### PR DESCRIPTION
blackfriday v2 introduced "HTMLSpan" as a node-type, causing go-md2man
to produce warnings as it didn't have specific handling for these nodes.

This patch makes go-md2man ignore these node types (e.g. <span> elements,
or <svg>), and skip the element themselves (only rendering their content,
if any), to prevent go-md2man printing noisy warnings during generation:

    WARNING: go-md2man does not handle node type HTMLSpan
    WARNING: go-md2man does not handle node type HTMLSpan
    WARNING: go-md2man does not handle node type HTMLSpan
    WARNING: go-md2man does not handle node type HTMLSpan
    WARNING: go-md2man does not handle node type HTMLSpan
    ...
