### PR TITLE
Add support for MarkDown headings formatted as "COMMAND(1) ..."

### DIFF
--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -31,9 +31,44 @@ func TestFirstHeading(t *testing.T) {
 % JUNE 2014
 `,
 		`.nh
-.TH "DOCKER" "1" Docker User Manuals
-Docker Community
-JUNE 2014`,
+.TH "DOCKER" "1" "Docker User Manuals" "Docker Community" "JUNE 2014"`,
+
+		`% DOCKER(1) "Docker User Manuals"
+% "Docker Community"
+% "JUNE 2014"
+`,
+		`.nh
+.TH "DOCKER" "1" "Docker User Manuals" "Docker Community" "JUNE 2014"`,
+
+		`% DOCKER(1)
+% JUNE 2014
+`,
+		`.nh
+.TH "DOCKER" "1" "JUNE 2014"`,
+
+		`% DOCKER 1
+% JUNE 2014
+`,
+		`.nh
+.TH DOCKER 1 "JUNE 2014"`,
+
+		`# DOCKER(1) JUNE 2014
+
+Here's a paragraph, following the first header.
+
+# SEE ALSO
+**docker-run(1)**
+`,
+		`.nh
+.TH "DOCKER" "1" "JUNE 2014"
+.PP
+Here's a paragraph, following the first header.
+
+
+.SH SEE ALSO
+.PP
+\fBdocker\-run(1)\fP
+`,
 	}
 	doTestsParam(t, tests, TestParams{})
 }

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -10,6 +10,34 @@ type TestParams struct {
 	extensions blackfriday.Extensions
 }
 
+func TestFirstHeading(t *testing.T) {
+	var tests = []string{
+		`DOCKER 1 "JUNE 2014" "Docker Community" "Docker User Manuals"
+====
+`,
+		`.nh
+.TH DOCKER 1 "JUNE 2014" "Docker Community" "Docker User Manuals"`,
+
+		`#   DOCKER(1) "JUNE 2014" "Docker Community" "Docker User Manuals"`,
+		`.nh
+.TH "DOCKER" "1" "JUNE 2014" "Docker Community" "Docker User Manuals"`,
+
+		`# "DOCKER(1)" "JUNE 2014" "Docker Community" "Docker User Manuals"`,
+		`.nh
+.TH "DOCKER" "1" "JUNE 2014" "Docker Community" "Docker User Manuals"`,
+
+		`% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+`,
+		`.nh
+.TH "DOCKER" "1" Docker User Manuals
+Docker Community
+JUNE 2014`,
+	}
+	doTestsParam(t, tests, TestParams{})
+}
+
 func TestEmphasis(t *testing.T) {
 	var tests = []string{
 		"nothing inline\n",
@@ -305,8 +333,12 @@ func execRecoverableTestSuite(t *testing.T, tests []string, params TestParams, s
 
 func runMarkdown(input string, params TestParams) string {
 	renderer := NewRoffRenderer()
+	extensions := params.extensions
+	if extensions == 0 {
+		extensions = renderer.extensions
+	}
 	return string(blackfriday.Run([]byte(input), blackfriday.WithRenderer(renderer),
-		blackfriday.WithExtensions(params.extensions)))
+		blackfriday.WithExtensions(extensions)))
 }
 
 func doTestsParam(t *testing.T, tests []string, params TestParams) {


### PR DESCRIPTION
relates to https://github.com/spf13/cobra/issues/1049 and https://github.com/docker/docker-ce-packaging/pull/502