### PR TITLE
Fix tables having additional row (revert #60) and fix #59

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -45,7 +45,7 @@ const (
 	dtTag            = "\n.TP\n"
 	dd2Tag           = "\n"
 	tableStart       = "\n.TS\nallbox;\n"
-	tableEnd         = "\n.TE\n"
+	tableEnd         = ".TE\n"
 	tableCellStart   = "T{\n"
 	tableCellEnd     = "\nT}\n"
 )

--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -259,7 +259,7 @@ func (r *roffRenderer) handleItem(w io.Writer, node *blackfriday.Node, entering 
 func (r *roffRenderer) handleTable(w io.Writer, node *blackfriday.Node, entering bool) {
 	if entering {
 		out(w, tableStart)
-		//call walker to count cells (and rows?) so format section can be produced
+		// call walker to count cells (and rows?) so format section can be produced
 		columns := countColumns(node)
 		out(w, strings.Repeat("l ", columns)+"\n")
 		out(w, strings.Repeat("l ", columns)+".\n")
@@ -283,9 +283,17 @@ func (r *roffRenderer) handleTableCell(w io.Writer, node *blackfriday.Node, ente
 			out(w, start)
 		}
 	} else {
-		// need to carriage return if we are at the end of the header row
-		if node.IsHeader && node.Next == nil {
-			end = end + crTag
+		if node.Next == nil {
+			if node.IsHeader {
+				// need to carriage return if we are at the end of the header row
+				end = end + crTag
+			} else if node.FirstChild == nil {
+				// empty cell: need to carriage return if we are at the end of
+				// the table, because handleText() will not be called if there's
+				// no text to preocess (which would otherwise add the trailing
+				// carriage return)
+				end = crTag
+			}
 		}
 		out(w, end)
 	}

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -266,7 +266,6 @@ zebra	T{
 Sometimes black and sometimes white, depending on the stripe.
 T}
 robin	red.
-
 .TE
 `,
 	}

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -272,6 +272,29 @@ robin	red.
 	doTestsInlineParam(t, tests, TestParams{blackfriday.Tables})
 }
 
+func TestTableWithEmptyCell(t *testing.T) {
+	var tests = []string{
+		`
+| Col1     | Col2  | Col3 |
+|:---------|:-----:|:----:| 
+| row one  |       |      | 
+| row two  | x     |      |
+`,
+		`.nh
+
+.TS
+allbox;
+l l l 
+l l l .
+\fB\fCCol1\fR	\fB\fCCol2\fR	\fB\fCCol3\fR
+row one		
+row two	x	
+.TE
+`,
+	}
+	doTestsInlineParam(t, tests, TestParams{blackfriday.Tables})
+}
+
 func TestLinks(t *testing.T) {
 	var tests = []string{
 		"See [docs](https://docs.docker.com/) for\nmore",


### PR DESCRIPTION
## 1. Revert "added linebreak before .TE (table end)"

This reverts https://github.com/cpuguy83/go-md2man/commit/1fc61eccc845e74b729c6d9f639efde0e0df0ddd (https://github.com/cpuguy83/go-md2man/pull/60) and https://github.com/cpuguy83/go-md2man/commit/6615cdb8ded68a260ec8d1b8382e19bab7611ce3

This change resulted in additional empty rows to be rendered in tables;

Before this revert:

       The operator can identify a container in three ways:

       ┌──────────────────────┬────────────────────────────────────────────────────────────────────┐
       │Identifier type       │ Example value                                                      │
       ├──────────────────────┼────────────────────────────────────────────────────────────────────┤
       │UUID long identifier  │ "f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778" │
       ├──────────────────────┼────────────────────────────────────────────────────────────────────┤
       │UUID short identifier │ "f78375b1c487"                                                     │
       ├──────────────────────┼────────────────────────────────────────────────────────────────────┤
       │Name                  │ "evil_ptolemy"                                                     │
       ├──────────────────────┼────────────────────────────────────────────────────────────────────┤
       │                      │                                                                    │
       └──────────────────────┴────────────────────────────────────────────────────────────────────┘

       The UUID identifiers come from the Docker daemon, and if a name is not

After this revert:

       The operator can identify a container in three ways:

       ┌──────────────────────┬────────────────────────────────────────────────────────────────────┐
       │Identifier type       │ Example value                                                      │
       ├──────────────────────┼────────────────────────────────────────────────────────────────────┤
       │UUID long identifier  │ "f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778" │
       ├──────────────────────┼────────────────────────────────────────────────────────────────────┤
       │UUID short identifier │ "f78375b1c487"                                                     │
       ├──────────────────────┼────────────────────────────────────────────────────────────────────┤
       │Name                  │ "evil_ptolemy"                                                     │
       └──────────────────────┴────────────────────────────────────────────────────────────────────┘

       The UUID identifiers come from the Docker daemon, and if a name is not


## 2. Fix missing carriage return before .TE if last table cell is empty

This is an alternative to https://github.com/cpuguy83/go-md2man/commit/1fc61eccc845e74b729c6d9f639efde0e0df0ddd (#60), which tried to address this same issue, but introduced a regression.

Before this, tables ending with an empty cell would miss a carriage return before the table closing marker (.TE), causing the table to not be closed, and rendering to be broken;

       ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─────────────────────┬─────────┐
       │Col1                                                                                                                                                                                          │ Co2                │ Col3    │
       ├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────┼─────────┤
       │row one                                                                                                                                                                                       │                     │ row two │
       ├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────┼─────────┤
       │                                                                                                                                                                                              │                     │         │
       ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────┼─────────┤
       │                                                                                                                                                                                              │                     │         │
       ├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────

After this patch, tables ending with an empty cell get a carriage return added
before the closing marker:

       ┌────────┬──────┬──────┐
       │Col1    │ Col2 │ Col3 │
       ├────────┼──────┼──────┤
       │row one │      │      │
       ├────────┼──────┼──────┤
       │row two │ x    │      │
       └────────┴──────┴──────┘
