### PR TITLE
Fix inline markup causing table cells to split

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -45,7 +45,7 @@ const (
 	dtTag            = "\n.TP\n"
 	dd2Tag           = "\n"
 	tableStart       = "\n.TS\nallbox;\n"
-	tableEnd         = "\n.TE\n"
+	tableEnd         = ".TE\n"
 	tableCellStart   = "T{\n"
 	tableCellEnd     = "\nT}\n"
 )

--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -91,7 +91,7 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 
 	switch node.Type {
 	case blackfriday.Text:
-		r.handleText(w, node, entering)
+		escapeSpecialChars(w, node.Literal)
 	case blackfriday.Softbreak:
 		out(w, crTag)
 	case blackfriday.Hardbreak:
@@ -151,40 +151,19 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 		out(w, codeCloseTag)
 	case blackfriday.Table:
 		r.handleTable(w, node, entering)
-	case blackfriday.TableCell:
-		r.handleTableCell(w, node, entering)
 	case blackfriday.TableHead:
 	case blackfriday.TableBody:
 	case blackfriday.TableRow:
 		// no action as cell entries do all the nroff formatting
 		return blackfriday.GoToNext
+	case blackfriday.TableCell:
+		r.handleTableCell(w, node, entering)
 	case blackfriday.HTMLSpan:
 		// ignore other HTML tags
 	default:
 		fmt.Fprintln(os.Stderr, "WARNING: go-md2man does not handle node type "+node.Type.String())
 	}
 	return walkAction
-}
-
-func (r *roffRenderer) handleText(w io.Writer, node *blackfriday.Node, entering bool) {
-	var (
-		start, end string
-	)
-	// handle special roff table cell text encapsulation
-	if node.Parent.Type == blackfriday.TableCell {
-		if len(node.Literal) > 30 {
-			start = tableCellStart
-			end = tableCellEnd
-		} else {
-			// end rows that aren't terminated by "tableCellEnd" with a cr if end of row
-			if node.Parent.Next == nil && node.Next == nil && !node.Parent.IsHeader {
-				end = crTag
-			}
-		}
-	}
-	out(w, start)
-	escapeSpecialChars(w, node.Literal)
-	out(w, end)
 }
 
 func (r *roffRenderer) handleHeading(w io.Writer, node *blackfriday.Node, entering bool) {
@@ -269,34 +248,39 @@ func (r *roffRenderer) handleTable(w io.Writer, node *blackfriday.Node, entering
 }
 
 func (r *roffRenderer) handleTableCell(w io.Writer, node *blackfriday.Node, entering bool) {
-	var (
-		start, end string
-	)
-	if node.IsHeader {
-		start = codespanTag
-		end = codespanCloseTag
-	}
 	if entering {
+		var start string
 		if node.Prev != nil && node.Prev.Type == blackfriday.TableCell {
-			out(w, "\t"+start)
-		} else {
-			out(w, start)
+			start = "\t"
 		}
+		if node.IsHeader {
+			start += codespanTag
+		} else if nodeLiteralSize(node) > 30 {
+			start += tableCellStart
+		}
+		out(w, start)
 	} else {
-		if node.Next == nil {
-			if node.IsHeader {
-				// need to carriage return if we are at the end of the header row
-				end = end + crTag
-			} else if node.FirstChild == nil {
-				// empty cell: need to carriage return if we are at the end of
-				// the table, because handleText() will not be called if there's
-				// no text to preocess (which would otherwise add the trailing
-				// carriage return)
-				end = crTag
-			}
+		var end string
+		if node.IsHeader {
+			end = codespanCloseTag
+		} else if nodeLiteralSize(node) > 30 {
+			end = tableCellEnd
+		}
+		if node.Next == nil && end != tableCellEnd {
+			// Last cell: need to carriage return if we are at the end of the
+			// header row and content isn't wrapped in a "tablecell"
+			end += crTag
 		}
 		out(w, end)
 	}
+}
+
+func nodeLiteralSize(node *blackfriday.Node) int {
+	total := 0
+	for n := node.FirstChild; n != nil; n = n.FirstChild {
+		total += len(n.Literal)
+	}
+	return total
 }
 
 // because roff format requires knowing the column count before outputting any table

--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -177,7 +177,7 @@ func (r *roffRenderer) handleText(w io.Writer, node *blackfriday.Node, entering 
 			end = tableCellEnd
 		} else {
 			// end rows that aren't terminated by "tableCellEnd" with a cr if end of row
-			if node.Parent.Next == nil && !node.Parent.IsHeader {
+			if node.Parent.Next == nil && node.Next == nil && !node.Parent.IsHeader {
 				end = crTag
 			}
 		}

--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -259,7 +259,7 @@ func (r *roffRenderer) handleItem(w io.Writer, node *blackfriday.Node, entering 
 func (r *roffRenderer) handleTable(w io.Writer, node *blackfriday.Node, entering bool) {
 	if entering {
 		out(w, tableStart)
-		//call walker to count cells (and rows?) so format section can be produced
+		// call walker to count cells (and rows?) so format section can be produced
 		columns := countColumns(node)
 		out(w, strings.Repeat("l ", columns)+"\n")
 		out(w, strings.Repeat("l ", columns)+".\n")
@@ -283,9 +283,17 @@ func (r *roffRenderer) handleTableCell(w io.Writer, node *blackfriday.Node, ente
 			out(w, start)
 		}
 	} else {
-		// need to carriage return if we are at the end of the header row
-		if node.IsHeader && node.Next == nil {
-			end = end + crTag
+		if node.Next == nil {
+			if node.IsHeader {
+				// need to carriage return if we are at the end of the header row
+				end = end + crTag
+			} else if node.FirstChild == nil {
+				// empty cell: need to carriage return if we are at the end of
+				// the table, because handleText() will not be called if there's
+				// no text to preocess (which would otherwise add the trailing
+				// carriage return)
+				end = crTag
+			}
 		}
 		out(w, end)
 	}

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -295,6 +295,39 @@ row two	x
 	doTestsInlineParam(t, tests, TestParams{blackfriday.Tables})
 }
 
+func TestTableWrapping(t *testing.T) {
+	var tests = []string{
+		`
+| Col1        | Col2                                      |
+| ----------- | ----------------------------------------- |
+| row one     | This is a short line.                     |
+| row\|two    | Col1 should not wrap.                     |
+| row three   | no\|wrap                                  |
+| row four    | Inline _cursive_ should not wrap.         |
+| row five    | Inline ` + "`code`" + ` should not wrap.  |
+| row six     | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eu ipsum eget tortor aliquam accumsan. Quisque ac turpis convallis, sagittis urna ac, tempor est. Mauris nibh arcu, hendrerit id eros sed, sodales lacinia ex. Suspendisse sed condimentum urna, vitae mattis lectus. Mauris imperdiet magna vel purus pretium, id interdum libero. |
+`,
+		`.nh
+
+.TS
+allbox;
+l l 
+l l .
+\fB\fCCol1\fR	\fB\fCCol2\fR
+row one	This is a short line.
+row|two	Col1 should not wrap.
+row three	no|wrap
+row four	Inline \fIcursive\fP should not wrap.
+row five	Inline \fB\fCcode\fR should not wrap.
+row six	T{
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eu ipsum eget tortor aliquam accumsan. Quisque ac turpis convallis, sagittis urna ac, tempor est. Mauris nibh arcu, hendrerit id eros sed, sodales lacinia ex. Suspendisse sed condimentum urna, vitae mattis lectus. Mauris imperdiet magna vel purus pretium, id interdum libero.
+T}
+.TE
+`,
+	}
+	doTestsInlineParam(t, tests, TestParams{blackfriday.Tables})
+}
+
 func TestLinks(t *testing.T) {
 	var tests = []string{
 		"See [docs](https://docs.docker.com/) for\nmore",

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -266,7 +266,6 @@ zebra	T{
 Sometimes black and sometimes white, depending on the stripe.
 T}
 robin	red.
-
 .TE
 `,
 	}

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -298,14 +298,15 @@ row two	x
 func TestTableWrapping(t *testing.T) {
 	var tests = []string{
 		`
-| Col1        | Col2                                      |
-| ----------- | ----------------------------------------- |
-| row one     | This is a short line.                     |
-| row\|two    | Col1 should not wrap.                     |
-| row three   | no\|wrap                                  |
-| row four    | Inline _cursive_ should not wrap.         |
-| row five    | Inline ` + "`code`" + ` should not wrap.  |
-| row six     | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eu ipsum eget tortor aliquam accumsan. Quisque ac turpis convallis, sagittis urna ac, tempor est. Mauris nibh arcu, hendrerit id eros sed, sodales lacinia ex. Suspendisse sed condimentum urna, vitae mattis lectus. Mauris imperdiet magna vel purus pretium, id interdum libero. |
+| Col1        | Col2                                             |
+| ----------- | ------------------------------------------------ |
+| row one     | This is a short line.                            |
+| row\|two    | Col1 should not wrap.                            |
+| row three   | no\|wrap                                         |
+| row four    | Inline _cursive_ should not wrap.                |
+| row five    | Inline ` + "`code markup`" + ` should not wrap.  |
+| row six     | A line that's longer than 30 characters with inline ` + "`code markup`" + ` or _cursive_ should not wrap.  |
+| row seven   | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eu ipsum eget tortor aliquam accumsan. Quisque ac turpis convallis, sagittis urna ac, tempor est. Mauris nibh arcu, hendrerit id eros sed, sodales lacinia ex. Suspendisse sed condimentum urna, vitae mattis lectus. Mauris imperdiet magna vel purus pretium, id interdum libero. |
 `,
 		`.nh
 
@@ -318,8 +319,11 @@ row one	This is a short line.
 row|two	Col1 should not wrap.
 row three	no|wrap
 row four	Inline \fIcursive\fP should not wrap.
-row five	Inline \fB\fCcode\fR should not wrap.
+row five	Inline \fB\fCcode markup\fR should not wrap.
 row six	T{
+A line that's longer than 30 characters with inline \fB\fCcode markup\fR or \fIcursive\fP should not wrap.
+T}
+row seven	T{
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eu ipsum eget tortor aliquam accumsan. Quisque ac turpis convallis, sagittis urna ac, tempor est. Mauris nibh arcu, hendrerit id eros sed, sodales lacinia ex. Suspendisse sed condimentum urna, vitae mattis lectus. Mauris imperdiet magna vel purus pretium, id interdum libero.
 T}
 .TE

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -272,6 +272,29 @@ robin	red.
 	doTestsInlineParam(t, tests, TestParams{blackfriday.Tables})
 }
 
+func TestTableWithEmptyCell(t *testing.T) {
+	var tests = []string{
+		`
+| Col1     | Col2  | Col3 |
+|:---------|:-----:|:----:| 
+| row one  |       |      | 
+| row two  | x     |      |
+`,
+		`.nh
+
+.TS
+allbox;
+l l l 
+l l l .
+\fB\fCCol1\fR	\fB\fCCol2\fR	\fB\fCCol3\fR
+row one		
+row two	x	
+.TE
+`,
+	}
+	doTestsInlineParam(t, tests, TestParams{blackfriday.Tables})
+}
+
 func TestLinks(t *testing.T) {
 	var tests = []string{
 		"See [docs](https://docs.docker.com/) for\nmore",


### PR DESCRIPTION
relates to / addresses https://github.com/docker/cli/issues/2985

Before this change, markup inside a table cell would introduce a newline, which resulted in those parts creating a new table row/cell:

       ┌───────────────────────────────┬───────────────────────────┐
       │Col1                           │ Col2                      │
       ├───────────────────────────────┼───────────────────────────┤
       │row|one                        │ Col1 should not wrap.     │
       ├───────────────────────────────┼───────────────────────────┤
       │row two                        │ no                        │
       ├───────────────────────────────┼───────────────────────────┤
       │|                              │                           │
       ├───────────────────────────────┼───────────────────────────┤
       │wrap                           │                           │
       ├───────────────────────────────┼───────────────────────────┤
       │row three                      │ Inline                    │
       ├───────────────────────────────┼───────────────────────────┤
       │cursive markup should not wrap │                           │
       ├───────────────────────────────┼───────────────────────────┤
       │row four                       │ Inline                    │
       ├───────────────────────────────┼───────────────────────────┤
       │code markup should not wrap    │                           │
       └───────────────────────────────┴───────────────────────────┘

After this change, markup does not introduce a newline, and content is correctly
rendered in a single table row / cell:

       ┌───────────────────────────────┬───────────────────────────┐
       │Col1                           │ Col2                      │
       ├───────────────────────────────┼───────────────────────────┤
       │row|one                        │ Col1 should not wrap.     │
       ├───────────────────────────────┼───────────────────────────┤
       │row two                        │ no|wrap                   │
       ├───────────────────────────────┼───────────────────────────┤
       │row three                      │ Inline cursive markup     │
       │                               │ should not wrap           │
       ├───────────────────────────────┼───────────────────────────┤
       │row four                       │ Inline core markup should │
       │                               │ not wrap                  │
       └───────────────────────────────┴───────────────────────────┘

Closes #68