### PR TITLE
Fix handling multiple definition descriptions

### DIFF
--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -196,6 +196,8 @@ func TestListLists(t *testing.T) {
 	var tests = []string{
 		"\n\n**[grpc]**\n: Section for gRPC socket listener settings. Contains three properties:\n - **address** (Default: \"/run/containerd/containerd.sock\")\n - **uid** (Default: 0)\n - **gid** (Default: 0)",
 		".nh\n\n.TP\n\\fB[grpc]\\fP\nSection for gRPC socket listener settings. Contains three properties:\n.RS\n.IP \\(bu 2\n\\fBaddress\\fP (Default: \"/run/containerd/containerd.sock\")\n.IP \\(bu 2\n\\fBuid\\fP (Default: 0)\n.IP \\(bu 2\n\\fBgid\\fP (Default: 0)\n\n.RE\n\n",
+		"Definition title\n: Definition description one\n: And two\n: And three\n",
+		".nh\n\n.TP\nDefinition title\nDefinition description one\n\nAnd two\n\nAnd three\n",
 	}
 	doTestsParam(t, tests, TestParams{blackfriday.DefinitionLists})
 }


### PR DESCRIPTION
The following valid markdown code:

	Some term (DT)
	: Description (DD1).
	: Also description (DD2).

is currently not handled correctly, resulting in this roff output

	.TP
	Some term (DT)
	Description (DD1).

	.TP
	Also description (DD2).

In other words, the second definition description (DD2) is
misrepresented as a separate definition title.

This happens because the code is not looking into ListTypeTerm flag
(perhaps it was not supported at the time of writing?), instead
alternating between DT and DD (assuming DD goes after DT and vice
versa), which is not the case if we have two DTs.

The fix is to check the ListTypeTerm flag: if set, this is a DT,
otherwise a DD.

Unfortunately we still have to use a state variable. This is because the
first DD should follow the DT immediately (i.e. no extra newlines or
anything), while the subsequent DDs needs to be separated with an extra
newline.

With these fixes, the above input results in:

	.TP
	Some term (DT)
	Description (DD1).

	Also description (DD2).

which is rendered by GNU troff + man macros to something like:

	Some term (DT)
		Description (DD1).

		Also description (DD2).

Add a test case to verify the fix and avoid future regressions.