### PR TITLE
Refresh and improve CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,12 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          # must be specified without patch version
+          version: v1.41

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-versions: [1.12.x, 1.13.x, 1.14.x]
-        platform: [ubuntu-latest]
+        go-versions: [1.13.x, 1.15.x, 1.16.x]
+        platform: [ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,9 @@ build: bin/go-md2man
 clean:
 	@rm -rf bin/*
 
-.PHONY: check
-check: lint
-
 .PHONY: test
 test:
 	@go test $(TEST_FLAGS) ./...
-
-.PHONY: lint
-lint:
-	@$(LINTER_BIN) run --new-from-rev "HEAD~$(git rev-list master.. --count)" ./...
 
 bin/go-md2man: actual_build_flags := $(BUILD_FLAGS) -o bin/go-md2man
 bin/go-md2man: bin
@@ -27,12 +20,6 @@ bin/go-md2man: bin
 
 bin:
 	@mkdir ./bin
-
-$(LINTER_BIN): linter_bin_path := $(shell which $(LINTER_BIN))
-$(LINTER_BIN):
-	@if [ -z $(linter_bin_path) ] || [ ! -x $(linter_bin_path) ]; then \
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.15.0; \
-	fi
 
 .PHONY: mod
 mod:


### PR DESCRIPTION
0. Add golangci-lint job (which used to be part of Travis-CI but was not moved over to GHA).

1. Update Go versions used in tests to current stable releases
       (plus 1.13 which is still used by Moby).
    
2. Explicitly specify ubuntu version used.
    
3. Bump actions/setup-go to v2.

