### PR TITLE
Do not escape dash, underscore, and ampersand

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -309,15 +309,6 @@ func out(w io.Writer, output string) {
 	io.WriteString(w, output) // nolint: errcheck
 }
 
-func needsBackslash(c byte) bool {
-	for _, r := range []byte("-_&\\") {
-		if c == r {
-			return true
-		}
-	}
-	return false
-}
-
 func escapeSpecialChars(w io.Writer, text []byte) {
 	for i := 0; i < len(text); i++ {
 		// escape initial apostrophe or period
@@ -328,7 +319,7 @@ func escapeSpecialChars(w io.Writer, text []byte) {
 		// directly copy normal characters
 		org := i
 
-		for i < len(text) && !needsBackslash(text[i]) {
+		for i < len(text) && text[i] != '\\' {
 			i++
 		}
 		if i > org {

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -52,13 +52,13 @@ func TestEmphasis(t *testing.T) {
 		".nh\n\n.PP\nover \\fItwo\nlines\\fP test\n",
 
 		"odd _number of_ markers_ here\n",
-		".nh\n\n.PP\nodd \\fInumber of\\fP markers\\_ here\n",
+		".nh\n\n.PP\nodd \\fInumber of\\fP markers_ here\n",
 
 		"odd _number\nof_ markers_ here\n",
-		".nh\n\n.PP\nodd \\fInumber\nof\\fP markers\\_ here\n",
+		".nh\n\n.PP\nodd \\fInumber\nof\\fP markers_ here\n",
 
 		"mix of *markers_\n",
-		".nh\n\n.PP\nmix of *markers\\_\n",
+		".nh\n\n.PP\nmix of *markers_\n",
 
 		"*What is A\\* algorithm?*\n",
 		".nh\n\n.PP\n\\fIWhat is A* algorithm?\\fP\n",
@@ -108,13 +108,13 @@ func TestStrong(t *testing.T) {
 		".nh\n\n.PP\nover \\fBtwo\nlines\\fP test\n",
 
 		"odd __number of__ markers__ here\n",
-		".nh\n\n.PP\nodd \\fBnumber of\\fP markers\\_\\_ here\n",
+		".nh\n\n.PP\nodd \\fBnumber of\\fP markers__ here\n",
 
 		"odd __number\nof__ markers__ here\n",
-		".nh\n\n.PP\nodd \\fBnumber\nof\\fP markers\\_\\_ here\n",
+		".nh\n\n.PP\nodd \\fBnumber\nof\\fP markers__ here\n",
 
 		"mix of **markers__\n",
-		".nh\n\n.PP\nmix of **markers\\_\\_\n",
+		".nh\n\n.PP\nmix of **markers__\n",
 
 		"**`/usr`** : this folder is named `usr`\n",
 		".nh\n\n.PP\n\\fB\\fB\\fC/usr\\fR\\fP : this folder is named \\fB\\fCusr\\fR\n",
@@ -137,7 +137,7 @@ func TestEmphasisMix(t *testing.T) {
 		".nh\n\n.PP\n\\fB\\fItriple emphasis\\fP\\fP\n",
 
 		"***triple emphasis___\n",
-		".nh\n\n.PP\n***triple emphasis\\_\\_\\_\n",
+		".nh\n\n.PP\n***triple emphasis___\n",
 
 		"*__triple emphasis__*\n",
 		".nh\n\n.PP\n\\fI\\fBtriple emphasis\\fP\\fP\n",
@@ -169,7 +169,7 @@ func TestCodeSpan(t *testing.T) {
 		".nh\n\n.PP\na `single marker\n",
 
 		"a single multi-tick marker with ``` no text\n",
-		".nh\n\n.PP\na single multi\\-tick marker with ``` no text\n",
+		".nh\n\n.PP\na single multi-tick marker with ``` no text\n",
 
 		"markers with ` ` a space\n",
 		".nh\n\n.PP\nmarkers with  a space\n",
@@ -178,7 +178,7 @@ func TestCodeSpan(t *testing.T) {
 		".nh\n\n.PP\n\\fB\\fCsource code\\fR and a `stray\n",
 
 		"`source *with* _awkward characters_ in it`\n",
-		".nh\n\n.PP\n\\fB\\fCsource *with* \\_awkward characters\\_ in it\\fR\n",
+		".nh\n\n.PP\n\\fB\\fCsource *with* _awkward characters_ in it\\fR\n",
 
 		"`split over\ntwo lines`\n",
 		".nh\n\n.PP\n\\fB\\fCsplit over\ntwo lines\\fR\n",
@@ -343,7 +343,7 @@ func TestLinks(t *testing.T) {
 func TestEscapeCharacters(t *testing.T) {
 	var tests = []string{
 		"Test-one_two&three\\four~five",
-		".nh\n\n.PP\nTest\\-one\\_two\\&three\\\\four~five\n",
+		".nh\n\n.PP\nTest-one_two&three\\\\four~five\n",
 	}
 	doTestsInline(t, tests)
 }


### PR DESCRIPTION
Currently, we escape a few characters, such as

 * `-` (dash) becomes `\-` (arithmetic minus sign)
 * `_` (underscore) becomes `\_` (underline character)
 * `&` (ampersand) becomes `\&` (zero-width space!)

As a result, we have two bugs:

1. All `&` characters disappear from the resulting man page.

2. Dashes are quite longer, and underscores becomes underlines (the
   latter are lower). This is not reflected in text output, only in PDF
   etc, and in most cases (like file names, command line options etc)
   does not look good.

In fact, the only character that needs escaping is the backslash itself.
This is what this patch does, together with fixes to expected test
output.

The following commands were used to generate the example PDFs:
```console
$ bin/go-md2man < go-md2man.1.md > go-md2man.1
$ man -Tpdf ./go-md2man.1 > go-md2man.pdf
```

Before: [go-md2man-old.pdf](https://github.com/cpuguy83/go-md2man/files/6812049/go-md2man-old.pdf)

After: [go-md2man.pdf](https://github.com/cpuguy83/go-md2man/files/6812052/go-md2man.pdf)

Visual comparison:
![Screenshot from 2021-07-13 14-30-22](https://user-images.githubusercontent.com/4522509/125527857-59278e19-89b5-4f76-9fcc-44ee92e44f26.png)

Source for the above:
```man
.PP
.RS

.nf
Old: go\-md2man \-\-example \-in=go\-md2man.1.md \-out=go\-md2man.1.out
New: go-md2man --example -in=go-md2man.1.md -out=go-md2man.1.out

Old: \-\-\- \_\_\_ \&\&\& k\_p\_q\_\_y\_z
New: --- ___ &&& k_p_q__y_z
.fi
.RE
```
