### PR TITLE
Fix go version var in ci yaml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-versions: [1.13.x, 1.15.x, 1.16.x]
+        go-version: [1.13.x, 1.15.x, 1.16.x]
         platform: [ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Matrix var was not right and so it always installed go as if the version was empty.