### PR TITLE
Add release script for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,172 @@
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: go-md2man Release
+
+jobs:
+  check:
+    name: Check Signed Tag
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    outputs:
+      stringver: ${{ steps.contentrel.outputs.stringver }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          path: src/github.com/cpuguy83/go-md2man
+
+      - name: Check signature
+        run: |
+          releasever=${{ github.ref }}
+          releasever="${releasever#refs/tags/}"
+          TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
+          echo "${TAGCHECK}" | grep -q "error" && {
+              echo "::error::tag ${releasever} is not a signed tag. Failing release process."
+              exit 1
+          } || {
+              echo "Tag ${releasever} is signed."
+              exit 0
+          }
+        working-directory: src/github.com/cpuguy83/go-md2man
+
+      - name: Release content
+        id: contentrel
+        run: |
+          RELEASEVER=${{ github.ref }}
+          echo "::set-output name=stringver::${RELEASEVER#refs/tags/v}"
+          git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
+        working-directory: src/github.com/cpuguy83/go-md2man
+
+      - name: Save release notes
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-notes
+          path: src/github.com/cpuguy83/go-md2man/release-notes.md
+
+  build:
+    name: Build Release Binaries
+    runs-on: ${{ matrix.os }}
+    needs: [check]
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-2019]
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.6'
+
+      - name: Set env
+        shell: bash
+        env:
+          MOS: ${{ matrix.os }}
+        run: |
+          releasever=${{ github.ref }}
+          releasever="${releasever#refs/tags/}"
+          os=linux
+          [[ "${MOS}" =~ "windows" ]] && {
+            os=windows
+          }
+          echo "RELEASE_VER=${releasever}" >> $GITHUB_ENV
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "OS=${os}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          repository: cpuguy83/go-md2man
+          ref: ${{ github.ref }}
+          path: src/github.com/cpuguy83/go-md2man
+
+      - name: Make
+        shell: bash
+        run: |
+          make build
+          TARFILE="go-md2man-${RELEASE_VER#v}-${OS}-amd64.tar.gz"
+          tar czf ${TARFILE} bin/
+          sha256sum ${TARFILE} >${TARFILE}.sha256sum
+        working-directory: src/github.com/cpuguy83/go-md2man
+
+      - name: Save build binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: binaries-${{ matrix.os }}
+          path: src/github.com/cpuguy83/go-md2man/*.tar.gz*
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    needs: [build, check]
+
+    steps:
+      - name: Download builds and release notes
+        uses: actions/download-artifact@v2
+        with:
+          path: builds
+      - name: Catalog build assets for upload
+        id: catalog
+        run: |
+          _filenum=1
+          for i in "ubuntu-18.04" "windows-2019"; do
+            for f in `ls builds/binaries-${i}`; do
+              echo "::set-output name=file${_filenum}::${f}"
+              let "_filenum+=1"
+            done
+          done
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.1.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: go-md2man ${{ needs.check.outputs.stringver }}
+          body_path: ./builds/release-notes/release-notes.md
+          draft: false
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+      - name: Upload Linux tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./builds/binaries-ubuntu-18.04/${{ steps.catalog.outputs.file1 }}
+          asset_name: ${{ steps.catalog.outputs.file1 }}
+          asset_content_type: application/gzip
+      - name: Upload Linux sha256 sum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./builds/binaries-ubuntu-18.04/${{ steps.catalog.outputs.file2 }}
+          asset_name: ${{ steps.catalog.outputs.file2 }}
+          asset_content_type: text/plain
+      - name: Upload Windows tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./builds/binaries-windows-2019/${{ steps.catalog.outputs.file3 }}
+          asset_name: ${{ steps.catalog.outputs.file5 }}
+          asset_content_type: application/gzip
+      - name: Upload Windows sha256 sum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./builds/binaries-windows-2019/${{ steps.catalog.outputs.file4 }}
+          asset_name: ${{ steps.catalog.outputs.file6 }}
+          asset_content_type: text/plain


### PR DESCRIPTION
I'll be testing this to verify, but it's probably 99% correct. Generates a Windows and Linux amd64 binary, puts it in a tarball, creates a sha256 sum and uploads those 4 items to the release downloads. Would require that the release notes are attached to the signed tag so it can be pulled from there to make the release notes in the GH release page.

Questions: do we want another binary for arm64 or anything else? It wouldn't be tested of course, and I guess the Windows one isn't being tested either. This could be simplified just to create and upload the amd64 Linux binary as well.

Signed-off-by: Phil Estes <estesp@amazon.com>