### PR TITLE
Behave more like a regular POSIX utility

### DIFF
--- a/md2man.go
+++ b/md2man.go
@@ -23,8 +23,8 @@ func main() {
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		defer inFile.Close() // nolint: errcheck
 	}
-	defer inFile.Close() // nolint: errcheck
 
 	doc, err := ioutil.ReadAll(inFile)
 	if err != nil {


### PR DESCRIPTION
Don't close `stdin`, even at end-of-file.
(Although this doesn't affect the code as it stands, it makes it brittle when incorporating into a larger program, where closing fd#0 could lead to it being reassigned to some other purpose.)