### PR TITLE
Improve Link Rendering

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -110,7 +110,9 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 		}
 	case blackfriday.Link:
 		if !entering {
-			out(w, linkTag+string(node.LinkData.Destination)+linkCloseTag)
+			// Hyphens in a link must be escaped to avoid word-wrap in the rendered man page.
+			escapedLink := strings.ReplaceAll(string(node.LinkData.Destination), "-", "\\-")
+			out(w, linkTag+escapedLink+linkCloseTag)
 		}
 	case blackfriday.Image:
 		// ignore images

--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -1,6 +1,7 @@
 package md2man
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -109,11 +110,16 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 			out(w, strongCloseTag)
 		}
 	case blackfriday.Link:
-		if !entering {
-			// Hyphens in a link must be escaped to avoid word-wrap in the rendered man page.
-			escapedLink := strings.ReplaceAll(string(node.LinkData.Destination), "-", "\\-")
-			out(w, linkTag+escapedLink+linkCloseTag)
+		// Don't render the link text for automatic links, because this
+		// will only duplicate the URL in the roff output.
+		// See https://daringfireball.net/projects/markdown/syntax#autolink
+		if !bytes.Equal(node.LinkData.Destination, node.FirstChild.Literal) {
+			out(w, string(node.FirstChild.Literal))
 		}
+		// Hyphens in a link must be escaped to avoid word-wrap in the rendered man page.
+		escapedLink := strings.ReplaceAll(string(node.LinkData.Destination), "-", "\\-")
+		out(w, linkTag+escapedLink+linkCloseTag)
+		walkAction = blackfriday.SkipChildren
 	case blackfriday.Image:
 		// ignore images
 		walkAction = blackfriday.SkipChildren

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -338,6 +338,8 @@ func TestLinks(t *testing.T) {
 		".nh\n\n.PP\nSee docs\n\\[la]https://docs.docker.com/\\[ra] for\nmore\n",
 		"See [docs](https://docs-foo.docker.com/) for\nmore",
 		".nh\n\n.PP\nSee docs\n\\[la]https://docs\\-foo.docker.com/\\[ra] for\nmore\n",
+		"See <https://docs-foo.docker.com/> for\nmore",
+		".nh\n\n.PP\nSee \n\\[la]https://docs\\-foo.docker.com/\\[ra] for\nmore\n",
 	}
 	doTestsInline(t, tests)
 }

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -336,6 +336,8 @@ func TestLinks(t *testing.T) {
 	var tests = []string{
 		"See [docs](https://docs.docker.com/) for\nmore",
 		".nh\n\n.PP\nSee docs\n\\[la]https://docs.docker.com/\\[ra] for\nmore\n",
+		"See [docs](https://docs-foo.docker.com/) for\nmore",
+		".nh\n\n.PP\nSee docs\n\\[la]https://docs\\-foo.docker.com/\\[ra] for\nmore\n",
 	}
 	doTestsInline(t, tests)
 }


### PR DESCRIPTION
This PR improves link rendering in the manpages.

Escape hyphens in link destinations to prevent wrapping in the rendered manpage.
When links are wrapped it is neither possible to copy them nor will
the destination resolve properly in terminals which make them clickable.

See also https://liw.fi/manpages/#using-fonts