### PR TITLE
Do not typeset table headings in monospaced font

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -262,7 +262,7 @@ func (r *roffRenderer) handleTableCell(w io.Writer, node *blackfriday.Node, ente
 			start = "\t"
 		}
 		if node.IsHeader {
-			start += codespanTag
+			start += strongTag
 		} else if nodeLiteralSize(node) > 30 {
 			start += tableCellStart
 		}
@@ -270,7 +270,7 @@ func (r *roffRenderer) handleTableCell(w io.Writer, node *blackfriday.Node, ente
 	} else {
 		var end string
 		if node.IsHeader {
-			end = codespanCloseTag
+			end = strongCloseTag
 		} else if nodeLiteralSize(node) > 30 {
 			end = tableCellEnd
 		}

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -257,7 +257,7 @@ func TestTable(t *testing.T) {
 allbox;
 l l 
 l l .
-\fB\fCAnimal\fR	\fB\fCColor\fR
+\fBAnimal\fP	\fBColor\fP
 elephant	T{
 Gray. The elephant is very gray.
 T}
@@ -286,7 +286,7 @@ func TestTableWithEmptyCell(t *testing.T) {
 allbox;
 l l l 
 l l l .
-\fB\fCCol1\fR	\fB\fCCol2\fR	\fB\fCCol3\fR
+\fBCol1\fP	\fBCol2\fP	\fBCol3\fP
 row one		
 row two	x	
 .TE
@@ -314,7 +314,7 @@ func TestTableWrapping(t *testing.T) {
 allbox;
 l l 
 l l .
-\fB\fCCol1\fR	\fB\fCCol2\fR
+\fBCol1\fP	\fBCol2\fP
 row one	This is a short line.
 row|two	Col1 should not wrap.
 row three	no|wrap


### PR DESCRIPTION
Table headings typeset in monospaced font look ugly (this can only be seen when rendered into Postscript or PDF). Using bold font is enough.

Before:
![image](https://user-images.githubusercontent.com/4522509/232637136-9c15bbfc-c3d9-487f-a88b-27485c5aa531.png)

After:
![image](https://user-images.githubusercontent.com/4522509/232637488-c486f22d-0099-417a-908e-9bf494f27d17.png)
