### PR TITLE
Don't warn on top-level comments

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -167,6 +167,11 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 		r.handleTableCell(w, node, entering)
 	case blackfriday.HTMLSpan:
 		// ignore other HTML tags
+	case blackfriday.HTMLBlock:
+		if bytes.HasPrefix(node.Literal, []byte("<!--")) {
+			break // ignore comments, no warning
+		}
+		fmt.Fprintln(os.Stderr, "WARNING: go-md2man does not handle node type "+node.Type.String())
 	default:
 		fmt.Fprintln(os.Stderr, "WARNING: go-md2man does not handle node type "+node.Type.String())
 	}

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -398,6 +398,20 @@ July 2014, updated by Sven Dowideit (SvenDowideit@home.org.au)
 	doTestsInline(t, tests)
 }
 
+func TestComments(t *testing.T) {
+	blockTests := []string{
+		"First paragraph\n\n<!-- Comment, HTML should be separated by blank lines -->\n\nSecond paragraph\n",
+		".nh\n\n.PP\nFirst paragraph\n\n.PP\nSecond paragraph\n",
+	}
+	doTestsParam(t, blockTests, TestParams{})
+
+	inlineTests := []string{
+		"Text with a com<!--...-->ment in the middle\n",
+		".nh\n\n.PP\nText with a comment in the middle\n",
+	}
+	doTestsInlineParam(t, inlineTests, TestParams{})
+}
+
 func execRecoverableTestSuite(t *testing.T, tests []string, params TestParams, suite func(candidate *string)) {
 	// Catch and report panics. This is useful when running 'go test -v' on
 	// the integration server. When developing, though, crash dump is often


### PR DESCRIPTION
Motivated by https://github.com/containers/image/issues/2128 .

Run the tests with `-v` to see that there are no warnings.