### PR TITLE
Prepend table preprocessor

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -21,34 +21,35 @@ type roffRenderer struct {
 }
 
 const (
-	titleHeader      = ".TH "
-	topLevelHeader   = "\n\n.SH "
-	secondLevelHdr   = "\n.SH "
-	otherHeader      = "\n.SS "
-	crTag            = "\n"
-	emphTag          = "\\fI"
-	emphCloseTag     = "\\fP"
-	strongTag        = "\\fB"
-	strongCloseTag   = "\\fP"
-	breakTag         = "\n.br\n"
-	paraTag          = "\n.PP\n"
-	hruleTag         = "\n.ti 0\n\\l'\\n(.lu'\n"
-	linkTag          = "\n\\[la]"
-	linkCloseTag     = "\\[ra]"
-	codespanTag      = "\\fB"
-	codespanCloseTag = "\\fR"
-	codeTag          = "\n.EX\n"
-	codeCloseTag     = "\n.EE\n"
-	quoteTag         = "\n.PP\n.RS\n"
-	quoteCloseTag    = "\n.RE\n"
-	listTag          = "\n.RS\n"
-	listCloseTag     = "\n.RE\n"
-	dtTag            = "\n.TP\n"
-	dd2Tag           = "\n"
-	tableStart       = "\n.TS\nallbox;\n"
-	tableEnd         = ".TE\n"
-	tableCellStart   = "T{\n"
-	tableCellEnd     = "\nT}\n"
+	titleHeader       = ".TH "
+	topLevelHeader    = "\n\n.SH "
+	secondLevelHdr    = "\n.SH "
+	otherHeader       = "\n.SS "
+	crTag             = "\n"
+	emphTag           = "\\fI"
+	emphCloseTag      = "\\fP"
+	strongTag         = "\\fB"
+	strongCloseTag    = "\\fP"
+	breakTag          = "\n.br\n"
+	paraTag           = "\n.PP\n"
+	hruleTag          = "\n.ti 0\n\\l'\\n(.lu'\n"
+	linkTag           = "\n\\[la]"
+	linkCloseTag      = "\\[ra]"
+	codespanTag       = "\\fB"
+	codespanCloseTag  = "\\fR"
+	codeTag           = "\n.EX\n"
+	codeCloseTag      = "\n.EE\n"
+	quoteTag          = "\n.PP\n.RS\n"
+	quoteCloseTag     = "\n.RE\n"
+	listTag           = "\n.RS\n"
+	listCloseTag      = "\n.RE\n"
+	dtTag             = "\n.TP\n"
+	dd2Tag            = "\n"
+	tableStart        = "\n.TS\nallbox;\n"
+	tableEnd          = ".TE\n"
+	tableCellStart    = "T{\n"
+	tableCellEnd      = "\nT}\n"
+	tablePreprocessor = `'\" t`
 )
 
 // NewRoffRenderer creates a new blackfriday Renderer for generating roff documents
@@ -75,6 +76,16 @@ func (r *roffRenderer) GetExtensions() blackfriday.Extensions {
 
 // RenderHeader handles outputting the header at document start
 func (r *roffRenderer) RenderHeader(w io.Writer, ast *blackfriday.Node) {
+	// We need to walk the tree to check if there are any tables.
+	// If there are, we need to enable the roff table preprocessor.
+	ast.Walk(func(node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+		if node.Type == blackfriday.Table {
+			out(w, tablePreprocessor+"\n")
+			return blackfriday.Terminate
+		}
+		return blackfriday.GoToNext
+	})
+
 	// disable hyphenation
 	out(w, ".nh\n")
 }

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -263,7 +263,8 @@ func TestTable(t *testing.T) {
 | zebra        | Sometimes black and sometimes white, depending on the stripe.     |
 | robin | red. |
 `,
-		`.nh
+		`'\" t
+.nh
 
 .TS
 allbox;
@@ -292,7 +293,8 @@ func TestTableWithEmptyCell(t *testing.T) {
 | row one  |       |      | 
 | row two  | x     |      |
 `,
-		`.nh
+		`'\" t
+.nh
 
 .TS
 allbox;
@@ -320,7 +322,8 @@ func TestTableWrapping(t *testing.T) {
 | row six     | A line that's longer than 30 characters with inline ` + "`code markup`" + ` or _cursive_ should not wrap.  |
 | row seven   | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent eu ipsum eget tortor aliquam accumsan. Quisque ac turpis convallis, sagittis urna ac, tempor est. Mauris nibh arcu, hendrerit id eros sed, sodales lacinia ex. Suspendisse sed condimentum urna, vitae mattis lectus. Mauris imperdiet magna vel purus pretium, id interdum libero. |
 `,
-		`.nh
+		`'\" t
+.nh
 
 .TS
 allbox;


### PR DESCRIPTION
When a table is present we need to instruct groff to enable the table preprocessor.
This surpresses warnings from groff.

Fixes #99