### PR TITLE
Fix trailing newline in code blocks

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -38,7 +38,7 @@ const (
 	codespanTag       = "\\fB"
 	codespanCloseTag  = "\\fR"
 	codeTag           = "\n.EX\n"
-	codeCloseTag      = "\n.EE\n"
+	codeCloseTag      = ".EE\n" // Do not prepend a newline character since code blocks, by definition, include a newline already (or at least as how blackfriday gives us on).
 	quoteTag          = "\n.PP\n.RS\n"
 	quoteCloseTag     = "\n.RE\n"
 	listTag           = "\n.RS\n"

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -13,10 +13,14 @@ type TestParams struct {
 func TestCodeBlocks(t *testing.T) {
 	tests := []string{
 		"```\nsome code\n```\n",
-		".nh\n\n.EX\nsome code\n\n.EE\n",
+		".nh\n\n.EX\nsome code\n.EE\n",
 
 		"```bash\necho foo\n```\n",
-		".nh\n\n.EX\necho foo\n\n.EE\n",
+		".nh\n\n.EX\necho foo\n.EE\n",
+
+		// make sure literal new lines surrounding the markdown block are preserved as they are intentional
+		"```bash\n\nsome code\n\n```",
+		".nh\n\n.EX\n\nsome code\n\n.EE\n",
 	}
 	doTestsParam(t, tests, TestParams{blackfriday.FencedCode})
 }


### PR DESCRIPTION
Given this input:

> ```
> some code
> ```

We were adding an additional newline character before the code close tag even though the code block by definition already includes that newline.

e.g., blackfriday is hadning us `some code\n` as the literal content of the code block.

fixes #47