### PR TITLE
Fix rendering of lists

### DIFF
--- a/go-md2man.1.md
+++ b/go-md2man.1.md
@@ -13,6 +13,18 @@ written purely in Go so as to reduce dependencies on 3rd party libs.
 
 By default, the input is stdin and the output is stdout.
 
+# OPTIONS
+
+**-in=**_file_
+:   Path to markdown file to be processed.
+
+    Defaults to stdin.
+
+**-out=**_file_
+:   Path to output processed file.
+
+    Defaults to stdout.
+
 # EXAMPLES
 Convert the markdown file *go-md2man.1.md* into a manpage:
 ```

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -207,6 +207,14 @@ func TestCodeSpan(t *testing.T) {
 	doTestsInline(t, tests)
 }
 
+func TestFlatLists(t *testing.T) {
+	tests := []string{
+		"Paragraph\n\n- item one\n- item two\n- item three\n",
+		".nh\n\n.PP\nParagraph\n.IP \\(bu 2\nitem one\n.IP \\(bu 2\nitem two\n.IP \\(bu 2\nitem three\n",
+	}
+	doTestsInline(t, tests)
+}
+
 func TestListLists(t *testing.T) {
 	tests := []string{
 		"\n\n**[grpc]**\n: Section for gRPC socket listener settings. Contains three properties:\n - **address** (Default: \"/run/containerd/containerd.sock\")\n - **uid** (Default: 0)\n - **gid** (Default: 0)",

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -210,9 +210,11 @@ func TestCodeSpan(t *testing.T) {
 func TestListLists(t *testing.T) {
 	tests := []string{
 		"\n\n**[grpc]**\n: Section for gRPC socket listener settings. Contains three properties:\n - **address** (Default: \"/run/containerd/containerd.sock\")\n - **uid** (Default: 0)\n - **gid** (Default: 0)",
-		".nh\n\n.TP\n\\fB[grpc]\\fP\nSection for gRPC socket listener settings. Contains three properties:\n.RS\n.IP \\(bu 2\n\\fBaddress\\fP (Default: \"/run/containerd/containerd.sock\")\n.IP \\(bu 2\n\\fBuid\\fP (Default: 0)\n.IP \\(bu 2\n\\fBgid\\fP (Default: 0)\n\n.RE\n\n",
+		".nh\n\n.TP\n\\fB[grpc]\\fP\nSection for gRPC socket listener settings. Contains three properties:\n.RS\n.IP \\(bu 2\n\\fBaddress\\fP (Default: \"/run/containerd/containerd.sock\")\n.IP \\(bu 2\n\\fBuid\\fP (Default: 0)\n.IP \\(bu 2\n\\fBgid\\fP (Default: 0)\n.RE\n",
 		"Definition title\n: Definition description one\n: And two\n: And three\n",
 		".nh\n\n.TP\nDefinition title\nDefinition description one\n\nAnd two\n\nAnd three\n",
+		"Definition\n:    description\n\n     split\n\n     over\n\n     multiple\n\n     paragraphs\n",
+		".nh\n\n.TP\nDefinition\ndescription\n\nsplit\n\nover\n\nmultiple\n\nparagraphs\n",
 	}
 	doTestsParam(t, tests, TestParams{blackfriday.DefinitionLists})
 }


### PR DESCRIPTION
The AST hierarchy for a list item is always `List` > `Item` > `Paragraph`. Emit newlines when visiting the `Paragraph` node instead of the `Item` and `List` so that `Item`s with multiple `Paragraphs` and nested `Lists` correctly render with just the right number of line breaks.

Update the man page to show off the new feature.

Stop over-indenting lists which are not nested inside a list item.

- Fixes #107 
- Closes #116

## Demo

<details><summary>Input</summary>
<p>

```markdown
test
====

text

**Term**
:   Def Autem repellendus recusandae sint deserunt non. Quas maxime delectus
    suscipit quis facere doloribus. Rerum omnis provident unde non sapiente
    magni.

**Long term**
:   Long definition

    Multiple paragraphs

    - including
    - lists
:   Second definition

more text

1. ordered lists

    Also multiple paragraphs
2. second item
    - with
    - nested

        Unordered second paragraph
    - item

    Another here
3. third
```

</p>
</details> 

<details><summary>Rendered terminal output</summary>
<p>

```
example(1)                  General Commands Manual                 example(1)

       text

       Term   Def Autem repellendus recusandae sint deserunt non. Quas maxime
              delectus suscipit quis facere doloribus. Rerum omnis provident
              unde non sapiente magni.


       Long term
              Long definition

              Multiple paragraphs

              • including

              • lists

              Second definition


       more text

         1. ordered lists

            Also multiple paragraphs

         2. second item

            • with

            • nested

              Unordered second paragraph

            • item

            Another here

         3. third

                                                                    example(1)
```

</p>
</details> 

<details><summary>Rendered output from master branch, for comparison</summary>
<p>

```
example(1)                  General Commands Manual                 example(1)

       text


       Term   Def Autem repellendus recusandae sint deserunt non. Quas maxime
              delectus suscipit quis facere doloribus. Rerum omnis provident
              unde non sapiente magni.


       Long term
              Long definitionMultiple paragraphs

              • including

              • lists



       Second definition


       more text


                1. ordered listsAlso multiple paragraphs

                2. second item

                   • with

                   • nestedUnordered second paragraph

                   • item

              Another here

                3. third


                                                                    example(1)
```

</p>
</details> 