### PR TITLE
Add debugging output for renderer

### DIFF
--- a/md2man/debug.go
+++ b/md2man/debug.go
@@ -1,0 +1,62 @@
+package md2man
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/russross/blackfriday/v2"
+)
+
+func fmtListFlags(flags blackfriday.ListType) string {
+	knownFlags := []struct {
+		name string
+		flag blackfriday.ListType
+	}{
+		{"ListTypeOrdered", blackfriday.ListTypeOrdered},
+		{"ListTypeDefinition", blackfriday.ListTypeDefinition},
+		{"ListTypeTerm", blackfriday.ListTypeTerm},
+		{"ListItemContainsBlock", blackfriday.ListItemContainsBlock},
+		{"ListItemBeginningOfList", blackfriday.ListItemBeginningOfList},
+		{"ListItemEndOfList", blackfriday.ListItemEndOfList},
+	}
+
+	var f []string
+	for _, kf := range knownFlags {
+		if flags&kf.flag != 0 {
+			f = append(f, kf.name)
+			flags &^= kf.flag
+		}
+	}
+	if flags != 0 {
+		f = append(f, fmt.Sprintf("Unknown(%#x)", flags))
+	}
+	return strings.Join(f, "|")
+}
+
+type debugDecorator struct {
+	blackfriday.Renderer
+}
+
+func depth(node *blackfriday.Node) int {
+	d := 0
+	for n := node.Parent; n != nil; n = n.Parent {
+		d++
+	}
+	return d
+}
+
+func (d *debugDecorator) RenderNode(w io.Writer, node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+	fmt.Fprintf(os.Stderr, "%s%s %v %v\n",
+		strings.Repeat("  ", depth(node)),
+		map[bool]string{true: "+", false: "-"}[entering],
+		node,
+		fmtListFlags(node.ListFlags))
+	var b strings.Builder
+	status := d.Renderer.RenderNode(io.MultiWriter(&b, w), node, entering)
+	if b.Len() > 0 {
+		fmt.Fprintf(os.Stderr, ">> %q\n", b.String())
+	}
+	return status
+}

--- a/md2man/md2man.go
+++ b/md2man/md2man.go
@@ -1,16 +1,23 @@
 package md2man
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/russross/blackfriday/v2"
 )
 
 // Render converts a markdown document into a roff formatted document.
 func Render(doc []byte) []byte {
 	renderer := NewRoffRenderer()
+	var r blackfriday.Renderer = renderer
+	if v, _ := strconv.ParseBool(os.Getenv("MD2MAN_DEBUG")); v {
+		r = &debugDecorator{Renderer: r}
+	}
 
 	return blackfriday.Run(doc,
 		[]blackfriday.Option{
-			blackfriday.WithRenderer(renderer),
+			blackfriday.WithRenderer(r),
 			blackfriday.WithExtensions(renderer.GetExtensions()),
 		}...)
 }


### PR DESCRIPTION
Documentation on the shape of the markdown AST produced by the blackfriday parser is rather sparse. Add a decorator for renderers which dumps the visited AST nodes to stderr, interleaved with the renderer output, to help with debugging the roff renderer.

<details><summary>Example</summary>
<p>

### Input

```markdown
Definition title
: Definition description one
: And two
: And three
```

### `MD2MAN_DEBUG=1` stderr output

```
+ Document: '' 
  + List: '' ListTypeDefinition|ListItemBeginningOfList
    + Item: '' ListTypeDefinition|ListTypeTerm|ListItemBeginningOfList
>> "\n.TP\n"
      + Paragraph: '' 
        + Text: 'Definition title' 
>> "Definition title"
      - Paragraph: '' 
    - Item: '' ListTypeDefinition|ListTypeTerm|ListItemBeginningOfList
>> "\n"
    + Item: '' ListTypeDefinition
      + Paragraph: '' 
        + Text: 'Definition descr...' 
>> "Definition description one"
      - Paragraph: '' 
    - Item: '' ListTypeDefinition
>> "\n"
    + Item: '' ListTypeDefinition
>> "\n"
      + Paragraph: '' 
        + Text: 'And two' 
>> "And two"
      - Paragraph: '' 
    - Item: '' ListTypeDefinition
>> "\n"
    + Item: '' ListTypeDefinition
>> "\n"
      + Paragraph: '' 
        + Text: 'And three' 
>> "And three"
      - Paragraph: '' 
    - Item: '' ListTypeDefinition
>> "\n"
  - List: '' ListTypeDefinition|ListItemBeginningOfList
- Document: '' 
```

</p>
</details> 