### PR TITLE
Emit a NAME section properly formatted for whatis parsing

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -145,7 +145,7 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 		if r.listDepth > 0 {
 			return blackfriday.GoToNext
 		}
-		if entering {
+		if entering && (node.Prev == nil || node.Prev.Type != blackfriday.Heading) {
 			out(w, paraTag)
 		} else {
 			out(w, crTag)

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -421,6 +421,14 @@ func TestComments(t *testing.T) {
 	doTestsInlineParam(t, inlineTests, TestParams{})
 }
 
+func TestHeadings(t *testing.T) {
+	tests := []string{
+		"# title\n\n# NAME\ncommand - description\n\n# SYNOPSIS\nA short description\n\nWhich spans multiple paragraphs\n",
+		".nh\n.TH title\n\n.SH NAME\ncommand - description\n\n\n.SH SYNOPSIS\nA short description\n\n.PP\nWhich spans multiple paragraphs\n",
+	}
+	doTestsInline(t, tests)
+}
+
 func execRecoverableTestSuite(t *testing.T, tests []string, params TestParams, suite func(candidate *string)) {
 	// Catch and report panics. This is useful when running 'go test -v' on
 	// the integration server. When developing, though, crash dump is often

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -424,7 +424,13 @@ func TestComments(t *testing.T) {
 func TestHeadings(t *testing.T) {
 	tests := []string{
 		"# title\n\n# NAME\ncommand - description\n\n# SYNOPSIS\nA short description\n\nWhich spans multiple paragraphs\n",
-		".nh\n.TH title\n\n.SH NAME\ncommand - description\n\n\n.SH SYNOPSIS\nA short description\n\n.PP\nWhich spans multiple paragraphs\n",
+		".nh\n.TH title\n\n.SH NAME\ncommand \\- description\n\n\n.SH SYNOPSIS\nA short description\n\n.PP\nWhich spans multiple paragraphs\n",
+
+		"# title\n\n# Name\nmy-command, other - description - with - hyphens\n",
+		".nh\n.TH title\n\n.SH Name\nmy-command, other \\- description - with - hyphens\n",
+
+		"# title\n\n# Not NAME\nsome - other - text\n",
+		".nh\n.TH title\n\n.SH Not NAME\nsome - other - text\n",
 	}
 	doTestsInline(t, tests)
 }


### PR DESCRIPTION
- Fixes #46 

Suppress `.PP` tags immediately following headers, and transform the first hyphen in the `NAME` section text to `\-` so that [generated man-pages follow the conventions required for proper indexing.](https://man7.org/linux/man-pages/man7/groff_man.7.html#:~:text=For%20example%2C%20a,be%20properly%20indexed.)

This does not affect the typeset output of man pages.