### PR TITLE
Preserve compatibility with go <= 1.17

### DIFF
--- a/md2man.go
+++ b/md2man.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/cpuguy83/go-md2man/v2/md2man"
@@ -28,7 +28,7 @@ func main() {
 	}
 	defer inFile.Close() // nolint: errcheck
 
-	doc, err := io.ReadAll(inFile)
+	doc, err := ioutil.ReadAll(inFile)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -104,7 +104,7 @@ func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering 
 			node.Parent.Prev.Type == blackfriday.Heading &&
 			node.Parent.Prev.FirstChild != nil &&
 			bytes.EqualFold(node.Parent.Prev.FirstChild.Literal, []byte("NAME")) {
-			before, after, found := bytes.Cut(node.Literal, []byte(" - "))
+			before, after, found := bytesCut(node.Literal, []byte(" - "))
 			escapeSpecialChars(w, before)
 			if found {
 				out(w, ` \- `)
@@ -405,4 +405,13 @@ func escapeSpecialCharsLine(w io.Writer, text []byte) {
 
 		w.Write([]byte{'\\', text[i]}) // nolint: errcheck
 	}
+}
+
+// bytesCut is a copy of [bytes.Cut] to provide compatibility with go1.17
+// and older. We can remove this once we drop support  for go1.17 and older.
+func bytesCut(s, sep []byte) (before, after []byte, found bool) {
+	if i := bytes.Index(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return s, nil, false
 }


### PR DESCRIPTION
- [x] depends on https://github.com/cpuguy83/go-md2man/pull/131
- revert https://github.com/cpuguy83/go-md2man/pull/125
- relates to https://github.com/spf13/cobra/pull/2201#issuecomment-2543996680


### Revert "md2man.go: rename ioutil to io" for compat with go <= 1.17

This reverts commit 76076049c2eabc4093673224cdb3dbccd2b5db1d.


### md2man: use local copy of bytes.Copy for compat with go < 1.1