### PR TITLE
gha: update golangci-lint to v1.62.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v6.1.1
         with:
-          version: v1.55
+          version: v1.62.2


### PR DESCRIPTION
The current version is not compatible with go1.23
