### PR TITLE
Update usage instructions and fix module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ go install github.com/cpuguy83/go-md2man/v2@latest
 
 go-md2man -in /path/to/markdownfile.md -out /manfile/output/path
 ```
+
+For go 1.24 and above, you can run it with `go tool`:
+
+```bash
+go get -tool github.com/cpuguy83/go-md2man/v2@latest
+# it will be appended to `tool` directive in go.mod file
+
+go tool go-md2man -in /path/to/markdownfile.md -out /manfile/output/path
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Uses [blackfriday](https://github.com/russross/blackfriday) to process markdown 
 ### Usage
 
 ```bash
-go install github.com/cpuguy83/go-md2man@latest
+go install github.com/cpuguy83/go-md2man/v2@latest
 
 go-md2man -in /path/to/markdownfile.md -out /manfile/output/path
 ```


### PR DESCRIPTION
The installation instructions should be corrected to use the `v2` module, which is the same as the module path in the `go.mod` file.

Add usage instructions for using go-md2man with the `go tool` for `go 1.24+`, refer to [go 1.24 release notes] and [tool dependencies] and [go module **tool** directive].

[go 1.24 release notes]: https://go.dev/doc/go1.24#go-command
[tool dependencies]: https://go.dev/doc/modules/managing-dependencies#tools
[go module **tool** directive]: https://go.dev/ref/mod#go-mod-file-tool