### PR TITLE
Table rendering fix

### DIFF
--- a/md2man/roff.go
+++ b/md2man/roff.go
@@ -47,7 +47,7 @@ const (
 	tableStart        = "\n.TS\nallbox;\n"
 	tableEnd          = ".TE\n"
 	tableCellStart    = "T{\n"
-	tableCellEnd      = "\nT}\n"
+	tableCellEnd      = "\nT}"
 	tablePreprocessor = `'\" t`
 )
 
@@ -316,9 +316,8 @@ func (r *roffRenderer) handleTableCell(w io.Writer, node *blackfriday.Node, ente
 		} else if nodeLiteralSize(node) > 30 {
 			end = tableCellEnd
 		}
-		if node.Next == nil && end != tableCellEnd {
-			// Last cell: need to carriage return if we are at the end of the
-			// header row and content isn't wrapped in a "tablecell"
+		if node.Next == nil {
+			// Last cell: need to carriage return if we are at the end of the header row.
 			end += crTag
 		}
 		out(w, end)

--- a/md2man/roff_test.go
+++ b/md2man/roff_test.go
@@ -276,6 +276,7 @@ func TestTable(t *testing.T) {
 | wombat     | No idea.      |
 | zebra        | Sometimes black and sometimes white, depending on the stripe.     |
 | robin | red. |
+| Meerschweinchen a.k.a. guinea pig | Varies. |
 `,
 		`'\" t
 .nh
@@ -293,6 +294,9 @@ zebra	T{
 Sometimes black and sometimes white, depending on the stripe.
 T}
 robin	red.
+T{
+Meerschweinchen a.k.a. guinea pig
+T}	Varies.
 .TE
 `,
 	}


### PR DESCRIPTION
Currently, when a long cell in the table is not the last (rightmost),
due to extra `\n` the rendering is broken, resulting in an extra row.

The fix is easy -- do not add `\n` after `T}` unless it's the last cell.

Add a test case, which (before the fix) is rendered like this:

	...

	│ robin                  │ red.                   │
	├────────────────────────┼────────────────────────┤
	│ Meerschweinchen a.k.a. │                        │
	│ guinea pig             │                        │
	├────────────────────────┼────────────────────────┤
	│                        │ Varies.                │
	└────────────────────────┴────────────────────────┘

With the fix, it is rendered correctly now:

	...

	│ robin                  │ red.                   │
	├────────────────────────┼────────────────────────┤
	│ Meerschweinchen a.k.a. │ Varies.                │
	│ guinea pig             │                        │
	└────────────────────────┴────────────────────────┘

Found while reading crun(1) man page (https://github.com/containers/crun/pull/1727)